### PR TITLE
BPI config

### DIFF
--- a/templates/bpi.conf.erb
+++ b/templates/bpi.conf.erb
@@ -4,7 +4,7 @@ define <%= @title %> {
 		desc=<%= @desc %>
 		primary=<%= @primary %>
 		info=<%= @info %>
-		members=<% @members.each_pair do |key, value| -%><%= key -%><%if value['service'] %>;<%= "#{value['service']}" -%><% end %><% if value['opt'] %>;<%= "#{value['opt']}" -%><% end %>, <% end %>
+		members=<% @members.each do |item| -%><%= "#{item['host']}" -%><% if item['service'] %>;<%= "#{item['service']}" -%><% end %><% if item['opt'] %>;<%= "#{item['opt']}" -%><% end %>, <% end %>
 		warning_threshold=<%= @warning_threshold %>
 		critical_threshold=<%= @critical_threshold %>
 		priority=<%= @priority %>


### PR DESCRIPTION
Handle BPI members as an array of hashes, so it is possible to monitor multiple services on the same host. Also take this opportunity to add documentation.